### PR TITLE
Add style attribute to Slack::BlockKit::Element::Button

### DIFF
--- a/lib/slack/block_kit/element/button.rb
+++ b/lib/slack/block_kit/element/button.rb
@@ -13,10 +13,11 @@ module Slack
 
         attr_accessor :confirm
 
-        def initialize(text:, action_id:, emoji: nil, url: nil, value: nil)
+        def initialize(text:, action_id:, style: nil, emoji: nil, url: nil, value: nil)
           @text = Composition::PlainText.new(text: text, emoji: emoji)
           @action_id = action_id
           @url = url
+          @style = style
           @value = value
 
           yield(self) if block_given?
@@ -37,6 +38,7 @@ module Slack
             action_id: @action_id,
             url: @url,
             value: @value,
+            style: @style,
             confirm: @confirm&.as_json
           }.compact
         end

--- a/lib/slack/block_kit/layout/actions.rb
+++ b/lib/slack/block_kit/layout/actions.rb
@@ -18,10 +18,11 @@ module Slack
           yield(self) if block_given?
         end
 
-        def button(text:, action_id:, emoji: nil, url: nil, value: nil)
+        def button(text:, action_id:, style: nil, emoji: nil, url: nil, value: nil)
           element = Element::Button.new(
             text: text,
             action_id: action_id,
+            style: style,
             emoji: emoji,
             url: url,
             value: value

--- a/lib/slack/block_kit/layout/section.rb
+++ b/lib/slack/block_kit/layout/section.rb
@@ -47,10 +47,11 @@ module Slack
           self
         end
 
-        def button(text:, action_id:, emoji: nil, url: nil, value: nil)
+        def button(text:, action_id:, style:, emoji: nil, url: nil, value: nil)
           element = Element::Button.new(
             text: text,
             action_id: action_id,
+            style: style,
             emoji: emoji,
             url: url,
             value: value


### PR DESCRIPTION
Slack now supports the `style` attribute, which may be one of:
- `default`
- `primary`
- `danger`

It's an optional attribute, if not sent will behave as if `default` was
sent.

See: https://api.slack.com/reference/messaging/block-elements#button